### PR TITLE
[fea] : 컬러에셋 추가 & 바로 사용할 수 있도록 코드 추가

### DIFF
--- a/GaNaDa/GaNaDa/Extension/UIColor+Extension.swift
+++ b/GaNaDa/GaNaDa/Extension/UIColor+Extension.swift
@@ -29,6 +29,15 @@ extension UIColor {
         )
     }
     
+    // 사용법 ex) label.background = .point
+    static let point = UIColor(named: "point")
+    static let customOrange = UIColor(named: "customOrange")
+    static let customIvory = UIColor(named: "customIvory")
+    static let black = UIColor(named: "black")
+    static let darkGray = UIColor(named: "darkGray")
+    static let lightGray = UIColor(named: "lightGray")
+
+    
     static func customColor(_ name: AssetsColor) -> UIColor {
         switch name {
         case .brand:

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/black.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/customIvory.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/customIvory.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.765",
+          "green" : "0.925",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/customOrange.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/customOrange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.678",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/darkGray.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/darkGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.463",
+          "green" : "0.463",
+          "red" : "0.463"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/lightGray.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/lightGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.592",
+          "green" : "0.592",
+          "red" : "0.592"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/point.colorset/Contents.json
+++ b/GaNaDa/GaNaDa/Resource/Assets/Assets.xcassets/Color/point.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.176",
+          "green" : "0.431",
+          "red" : "0.929"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 스프린트 2에서 사용할 컬러 에셋 추가
- default 컬러처럼 사용할 수 있도록 extension 추가

## Key Changes 🔥 (주요 구현/변경 사항)
<img width="729" alt="image" src="https://user-images.githubusercontent.com/59302419/181413241-01552fce-fa5a-43fa-b24b-19ebda39b005.png">

<img width="522" alt="image" src="https://user-images.githubusercontent.com/59302419/181413322-5d35f088-ba0f-4082-829e-bc5fcceb25a9.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

컬러를 사용할 곳에 .point 처럼 원래 default 값 쓰는 것처럼 사용하시면 됩니다!


## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)



## Reference 🔗



## Build ⚒ (Build 가능 여부)
 - [x] Yes
 - [ ] No

## Close Issues 🔒 (닫을 Issue)
Close #No.
