### PR TITLE
[fea] todayquiz에 블러적용 & choice 타입 연결

### DIFF
--- a/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.swift
@@ -10,27 +10,65 @@ import UIKit
 final class QuizTypeBlank: UICollectionViewCell {
     @IBOutlet weak var quizIndex: UILabel!
     @IBOutlet weak var quizQuestion: UILabel!
-    @IBOutlet weak var rightAnswer: UIButton!
-    @IBOutlet weak var wrongAnswer: UIButton!
 
+    lazy var visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+    var colorBlurView = UIView()
+    var flag: Bool = true
+    
     var data: Quiz = Quiz(question: "샘플 문장", type: QuizType.blank, rightAnswer: "정답", wrongAnswer: "오답") {
         didSet {
             quizQuestion.text = makeQuizSentence(quiz: data)
-            rightAnswer.setTitle(data.rightAnswer, for: UIControl.State.normal)
-            wrongAnswer.setTitle(data.wrongAnswer, for: UIControl.State.normal)
         }
     }
     
     override func awakeFromNib() {
         super.awakeFromNib()
         contentView.layer.cornerRadius = QuizType1LayoutValue.Cell.cornerLadius
+        contentView.layer.borderWidth = 2
+        contentView.layer.borderColor = UIColor.customOrange.cgColor
+    }
+    
+    deinit {
+        print("Deinit \(self)")
     }
 }
 
-private extension QuizTypeBlank {
+extension QuizTypeBlank {
+    func applyBlur() {
+        if flag {
+            self.addSubview(visualEffectView)
+            visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+            visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
+            visualEffectView.clipsToBounds = true
+            visualEffectView.layer.opacity = 0.9
+            NSLayoutConstraint.activate([
+                visualEffectView.topAnchor.constraint(equalTo: self.topAnchor),
+                visualEffectView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                visualEffectView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                visualEffectView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            ])
+            self.addSubview(colorBlurView)
+            colorBlurView.backgroundColor = .customIvory
+            colorBlurView.translatesAutoresizingMaskIntoConstraints = false
+            colorBlurView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
+            colorBlurView.clipsToBounds = true
+            colorBlurView.layer.opacity = 0.5
+            NSLayoutConstraint.activate([
+                colorBlurView.topAnchor.constraint(equalTo: self.topAnchor),
+                colorBlurView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                colorBlurView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                colorBlurView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            ])
+        } else {
+            visualEffectView.removeFromSuperview()
+            colorBlurView.removeFromSuperview()
+
+        }
+    }
+    
     func makeQuizSentence(quiz: Quiz) -> String {
         var quizQuestion = quiz.question
-        quizQuestion = quizQuestion.replacingOccurrences(of: "*", with: String(repeating: "_", count: quiz.rightAnswer.count + 2))
+        quizQuestion = quizQuestion.replacingOccurrences(of: "*", with: "( \(data.rightAnswer) / \(data.wrongAnswer) )")
         return quizQuestion
     }
     

--- a/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.swift
@@ -10,10 +10,6 @@ import UIKit
 final class QuizTypeBlank: UICollectionViewCell {
     @IBOutlet weak var quizIndex: UILabel!
     @IBOutlet weak var quizQuestion: UILabel!
-
-    lazy var visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
-    var colorBlurView = UIView()
-    var flag: Bool = true
     
     var data: Quiz = Quiz(question: "샘플 문장", type: QuizType.blank, rightAnswer: "정답", wrongAnswer: "오답") {
         didSet {
@@ -23,58 +19,16 @@ final class QuizTypeBlank: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        contentView.layer.cornerRadius = QuizType1LayoutValue.Cell.cornerLadius
+        contentView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
         contentView.layer.borderWidth = 2
         contentView.layer.borderColor = UIColor.customOrange.cgColor
-    }
-    
-    deinit {
-        print("Deinit \(self)")
     }
 }
 
 extension QuizTypeBlank {
-    func applyBlur() {
-        if flag {
-            self.addSubview(visualEffectView)
-            visualEffectView.translatesAutoresizingMaskIntoConstraints = false
-            visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
-            visualEffectView.clipsToBounds = true
-            visualEffectView.layer.opacity = 0.9
-            NSLayoutConstraint.activate([
-                visualEffectView.topAnchor.constraint(equalTo: self.topAnchor),
-                visualEffectView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-                visualEffectView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-                visualEffectView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-            ])
-            self.addSubview(colorBlurView)
-            colorBlurView.backgroundColor = .customIvory
-            colorBlurView.translatesAutoresizingMaskIntoConstraints = false
-            colorBlurView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
-            colorBlurView.clipsToBounds = true
-            colorBlurView.layer.opacity = 0.5
-            NSLayoutConstraint.activate([
-                colorBlurView.topAnchor.constraint(equalTo: self.topAnchor),
-                colorBlurView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-                colorBlurView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-                colorBlurView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-            ])
-        } else {
-            visualEffectView.removeFromSuperview()
-            colorBlurView.removeFromSuperview()
-
-        }
-    }
-    
     func makeQuizSentence(quiz: Quiz) -> String {
         var quizQuestion = quiz.question
         quizQuestion = quizQuestion.replacingOccurrences(of: "*", with: "( \(data.rightAnswer) / \(data.wrongAnswer) )")
         return quizQuestion
-    }
-    
-    struct QuizType1LayoutValue {
-        enum Cell {
-            static let cornerLadius = 16.0
-        }
     }
 }

--- a/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.xib
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/QuizTypeBlank.xib
@@ -19,74 +19,38 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="문제 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMd-tl-K2U">
-                        <rect key="frame" x="24" y="22" width="36" height="16.5"/>
-                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
+                        <rect key="frame" x="24" y="22" width="31" height="14"/>
+                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나는 iOS 개발자가 ____ 싶다." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tMP-fU-g21">
-                        <rect key="frame" x="24" y="61.5" width="300" height="16.5"/>
-                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
+                        <rect key="frame" x="24" y="59" width="300" height="17.5"/>
+                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="B1G-gO-lg9">
-                        <rect key="frame" x="14" y="101" width="324" height="34"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2BZ-IU-X3O">
-                                <rect key="frame" x="0.0" y="0.0" width="160" height="34"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="34" id="AY7-PX-RkH"/>
-                                    <constraint firstAttribute="width" constant="160" id="AgK-12-JUd"/>
-                                </constraints>
-                                <color key="tintColor" systemColor="systemCyanColor"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="정답">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="12"/>
-                                </buttonConfiguration>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1PE-uE-rgf">
-                                <rect key="frame" x="164" y="0.0" width="160" height="34"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="160" id="VmS-zg-uVZ"/>
-                                    <constraint firstAttribute="height" constant="34" id="wc8-i1-vjc"/>
-                                </constraints>
-                                <color key="tintColor" systemColor="systemCyanColor"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="오답">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="12"/>
-                                </buttonConfiguration>
-                            </button>
-                        </subviews>
-                    </stackView>
                 </subviews>
-                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 <constraints>
                     <constraint firstItem="tMP-fU-g21" firstAttribute="top" secondItem="nMd-tl-K2U" secondAttribute="bottom" constant="23" id="5pW-6P-sBO"/>
                     <constraint firstAttribute="trailing" secondItem="tMP-fU-g21" secondAttribute="trailing" constant="24" id="91F-6a-afu"/>
                     <constraint firstItem="tMP-fU-g21" firstAttribute="leading" secondItem="aJc-NF-WYa" secondAttribute="leading" constant="24" id="FyH-nf-zmO"/>
                     <constraint firstItem="nMd-tl-K2U" firstAttribute="leading" secondItem="aJc-NF-WYa" secondAttribute="leading" constant="24" id="PPF-Qh-AZR"/>
-                    <constraint firstItem="B1G-gO-lg9" firstAttribute="leading" secondItem="aJc-NF-WYa" secondAttribute="leading" constant="14" id="Ukx-nP-4g5"/>
                     <constraint firstItem="nMd-tl-K2U" firstAttribute="top" secondItem="aJc-NF-WYa" secondAttribute="top" constant="22" id="rEJ-Ch-MYN"/>
-                    <constraint firstItem="B1G-gO-lg9" firstAttribute="top" secondItem="tMP-fU-g21" secondAttribute="bottom" constant="23" id="xIw-Z5-McK"/>
                 </constraints>
             </collectionViewCellContentView>
             <size key="customSize" width="348" height="150"/>
             <connections>
                 <outlet property="quizIndex" destination="nMd-tl-K2U" id="N5m-KN-DIH"/>
                 <outlet property="quizQuestion" destination="tMP-fU-g21" id="EHA-fo-Utt"/>
-                <outlet property="rightAnswer" destination="2BZ-IU-X3O" id="umF-SH-e6j"/>
-                <outlet property="wrongAnswer" destination="1PE-uE-rgf" id="9JX-jL-kf0"/>
             </connections>
             <point key="canvasLocation" x="-278.26086956521743" y="-30.133928571428569"/>
         </collectionViewCell>
     </objects>
     <resources>
-        <systemColor name="systemCyanColor">
-            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
@@ -7,6 +7,11 @@
 
 import UIKit
 
+struct TodayQuizLayoutValue {
+    enum CornerRadius {
+        static let cell = 16.0
+    }
+}
 
 final class TodayQuizViewController: UIViewController {
 
@@ -16,9 +21,24 @@ final class TodayQuizViewController: UIViewController {
     @IBOutlet weak var userName: UILabel!
     @IBOutlet weak var userExp: UIProgressView!
     
+//    let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+    
+    var currentHour: Int = 0
+    var openTimes = [9,12,18]
+    
     var todayQuizs: [Quiz] = [Quiz(question: "나는 ios 개발자가 * 싶다.", type: QuizType.blank, rightAnswer: "되고", wrongAnswer: "돼고"),
                               Quiz(question: "정말 너를 * 좋니.", type: QuizType.blank, rightAnswer: "어떡하면", wrongAnswer: "어떻하면"),
                               Quiz(question: "오늘도 안 오면 *.", type: QuizType.blank, rightAnswer: "어떡해", wrongAnswer: "어떻게")]
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH"
+        currentHour = Int(formatter.string(from: Date())) ?? 0
+        print("\(currentHour)")
+        todayQuizCollectionView.reloadData()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,8 +50,7 @@ final class TodayQuizViewController: UIViewController {
         let todayQuizBlankCellNib = UINib(nibName: "QuizTypeBlank", bundle: nil)
         
         todayQuizCollectionView.register(todayQuizBlankCellNib, forCellWithReuseIdentifier: "todayQuizBlankCell")
-        
-        
+
         todayQuizCollectionView.dataSource = self
         
         todayQuizCollectionView.collectionViewLayout = creatCompositionalLayout()
@@ -64,7 +83,7 @@ private extension TodayQuizViewController {
         let layout = UICollectionViewCompositionalLayout{
             (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
             
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(171))
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(125))
             
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
@@ -84,7 +103,6 @@ private extension TodayQuizViewController {
     
 }
 
-
 extension TodayQuizViewController: UICollectionViewDelegate {
     
 }
@@ -96,9 +114,54 @@ extension TodayQuizViewController: UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: "todayQuizBlankCell", for: indexPath) as! QuizTypeBlank
-        
         cell.data = self.todayQuizs[indexPath.item]
         cell.quizIndex.text = "문제 \(indexPath.item + 1)"
+        
+        
+        if let openTimeLabel = cell.subviews.last as? UILabel {
+            openTimeLabel.removeFromSuperview()
+            if let visualEffectView = cell.subviews.last as? UIVisualEffectView {
+                visualEffectView.removeFromSuperview()
+            }
+        }
+        
+        if currentHour < openTimes[indexPath.item] {
+            print("blur \(currentHour) \(openTimes[indexPath.item])")
+            let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+            cell.addSubview(visualEffectView)
+            visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+            visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
+            visualEffectView.clipsToBounds = true
+            visualEffectView.layer.opacity = 0.9
+            NSLayoutConstraint.activate([
+                visualEffectView.topAnchor.constraint(equalTo: cell.topAnchor),
+                visualEffectView.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+                visualEffectView.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+                visualEffectView.bottomAnchor.constraint(equalTo: cell.bottomAnchor)
+            ])
+            
+            let imageAttachment = NSTextAttachment()
+            imageAttachment.image = UIImage(systemName: "lock.fill")
+            let fullString = NSMutableAttributedString(string: "")
+            fullString.append(NSAttributedString(attachment: imageAttachment))
+            
+            let openHour = String(format: "%02d:00", openTimes[indexPath.item])
+
+            
+            fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
+//            label.attributedText = fullString
+            
+            let openTimeLabel = UILabel()
+            openTimeLabel.attributedText = fullString
+            cell.addSubview(openTimeLabel)
+            openTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                openTimeLabel.centerXAnchor.constraint(equalTo: cell.centerXAnchor),
+                openTimeLabel.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            ])
+            
+        }
+
         return cell
     }
 }

--- a/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
@@ -27,7 +27,7 @@ final class TodayQuizViewController: UIViewController {
     var openTimes = [9,12,18]
     
     var todayQuizs: [Quiz] = [Quiz(question: "나는 ios 개발자가 * 싶다.", type: QuizType.blank, rightAnswer: "되고", wrongAnswer: "돼고"),
-                              Quiz(question: "정말 너를 * 좋니.", type: QuizType.blank, rightAnswer: "어떡하면", wrongAnswer: "어떻하면"),
+                              Quiz.previewChoice,
                               Quiz(question: "오늘도 안 오면 *.", type: QuizType.blank, rightAnswer: "어떡해", wrongAnswer: "어떻게")]
 
     override func viewDidAppear(_ animated: Bool) {
@@ -48,6 +48,8 @@ final class TodayQuizViewController: UIViewController {
         requestUserData()
         
         let todayQuizBlankCellNib = UINib(nibName: "QuizTypeBlank", bundle: nil)
+        
+        todayQuizCollectionView.register(QuizType2CollectionViewCell.self, forCellWithReuseIdentifier: QuizType2CollectionViewCell.id)
         
         todayQuizCollectionView.register(todayQuizBlankCellNib, forCellWithReuseIdentifier: "todayQuizBlankCell")
 
@@ -113,56 +115,61 @@ extension TodayQuizViewController: UICollectionViewDataSource{
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: "todayQuizBlankCell", for: indexPath) as! QuizTypeBlank
-        cell.data = self.todayQuizs[indexPath.item]
-        cell.quizIndex.text = "문제 \(indexPath.item + 1)"
-        
-        
-        if let openTimeLabel = cell.subviews.last as? UILabel {
-            openTimeLabel.removeFromSuperview()
-            if let visualEffectView = cell.subviews.last as? UIVisualEffectView {
-                visualEffectView.removeFromSuperview()
+
+        if todayQuizs[indexPath.item].type == QuizType.blank {
+            let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: "todayQuizBlankCell", for: indexPath) as! QuizTypeBlank
+            cell.data = self.todayQuizs[indexPath.item]
+            cell.quizIndex.text = "문제 \(indexPath.item + 1)"
+            
+            
+            if let openTimeLabel = cell.subviews.last as? UILabel {
+                openTimeLabel.removeFromSuperview()
+                if let visualEffectView = cell.subviews.last as? UIVisualEffectView {
+                    visualEffectView.removeFromSuperview()
+                }
             }
-        }
-        
-        if currentHour < openTimes[indexPath.item] {
-            print("blur \(currentHour) \(openTimes[indexPath.item])")
-            let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
-            cell.addSubview(visualEffectView)
-            visualEffectView.translatesAutoresizingMaskIntoConstraints = false
-            visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
-            visualEffectView.clipsToBounds = true
-            visualEffectView.layer.opacity = 0.9
-            NSLayoutConstraint.activate([
-                visualEffectView.topAnchor.constraint(equalTo: cell.topAnchor),
-                visualEffectView.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
-                visualEffectView.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
-                visualEffectView.bottomAnchor.constraint(equalTo: cell.bottomAnchor)
-            ])
             
-            let imageAttachment = NSTextAttachment()
-            imageAttachment.image = UIImage(systemName: "lock.fill")
-            let fullString = NSMutableAttributedString(string: "")
-            fullString.append(NSAttributedString(attachment: imageAttachment))
-            
-            let openHour = String(format: "%02d:00", openTimes[indexPath.item])
+            if currentHour < openTimes[indexPath.item] {
+                print("blur \(currentHour) \(openTimes[indexPath.item])")
+                let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+                cell.addSubview(visualEffectView)
+                visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+                visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
+                visualEffectView.clipsToBounds = true
+                visualEffectView.layer.opacity = 0.9
+                NSLayoutConstraint.activate([
+                    visualEffectView.topAnchor.constraint(equalTo: cell.topAnchor),
+                    visualEffectView.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+                    visualEffectView.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+                    visualEffectView.bottomAnchor.constraint(equalTo: cell.bottomAnchor)
+                ])
+                
+                let imageAttachment = NSTextAttachment()
+                imageAttachment.image = UIImage(systemName: "lock.fill")
+                let fullString = NSMutableAttributedString(string: "")
+                fullString.append(NSAttributedString(attachment: imageAttachment))
+                
+                let openHour = String(format: "%02d:00", openTimes[indexPath.item])
 
-            
-            fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
-//            label.attributedText = fullString
-            
-            let openTimeLabel = UILabel()
-            openTimeLabel.attributedText = fullString
-            cell.addSubview(openTimeLabel)
-            openTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                openTimeLabel.centerXAnchor.constraint(equalTo: cell.centerXAnchor),
-                openTimeLabel.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-            ])
-            
+                
+                fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
+                
+                let openTimeLabel = UILabel()
+                openTimeLabel.attributedText = fullString
+                cell.addSubview(openTimeLabel)
+                openTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    openTimeLabel.centerXAnchor.constraint(equalTo: cell.centerXAnchor),
+                    openTimeLabel.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                ])
+            }
+            return cell
+        } else {
+            guard let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: QuizType2CollectionViewCell.id, for: indexPath) as? QuizType2CollectionViewCell
+            else { return UICollectionViewCell() }
+            cell.setQuiz(quizNum: (indexPath.row) + 1, quiz: todayQuizs[indexPath.row])
+            return cell
         }
-
-        return cell
     }
 }
 

--- a/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
@@ -20,12 +20,9 @@ final class TodayQuizViewController: UIViewController {
     @IBOutlet weak var userLevel: UILabel!
     @IBOutlet weak var userName: UILabel!
     @IBOutlet weak var userExp: UIProgressView!
-    
-//    let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
-    
+        
     var currentHour: Int = 0
     var openTimes = [9,12,18]
-    
     var todayQuizs: [Quiz] = [Quiz(question: "나는 ios 개발자가 * 싶다.", type: QuizType.blank, rightAnswer: "되고", wrongAnswer: "돼고"),
                               Quiz.previewChoice,
                               Quiz(question: "오늘도 안 오면 *.", type: QuizType.blank, rightAnswer: "어떡해", wrongAnswer: "어떻게")]
@@ -121,7 +118,6 @@ extension TodayQuizViewController: UICollectionViewDataSource{
             cell.data = self.todayQuizs[indexPath.item]
             cell.quizIndex.text = "문제 \(indexPath.item + 1)"
             
-            
             if let openTimeLabel = cell.subviews.last as? UILabel {
                 openTimeLabel.removeFromSuperview()
                 if let visualEffectView = cell.subviews.last as? UIVisualEffectView {
@@ -150,8 +146,6 @@ extension TodayQuizViewController: UICollectionViewDataSource{
                 fullString.append(NSAttributedString(attachment: imageAttachment))
                 
                 let openHour = String(format: "%02d:00", openTimes[indexPath.item])
-
-                
                 fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
                 
                 let openTimeLabel = UILabel()
@@ -172,6 +166,14 @@ extension TodayQuizViewController: UICollectionViewDataSource{
         }
     }
 }
+
+extension TodayQuizViewController {
+    func applySecretEffect() {
+        
+        
+    }
+}
+
 
 enum level: Int {
     case lowNine = 0

--- a/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
@@ -22,7 +22,7 @@ final class TodayQuizViewController: UIViewController {
     @IBOutlet weak var userExp: UIProgressView!
         
     var currentHour: Int = 0
-    var openTimes = [9,12,18]
+    var openTimes = [9, 12, 18]
     var todayQuizs: [Quiz] = [Quiz(question: "나는 ios 개발자가 * 싶다.", type: QuizType.blank, rightAnswer: "되고", wrongAnswer: "돼고"),
                               Quiz.previewChoice,
                               Quiz(question: "오늘도 안 오면 *.", type: QuizType.blank, rightAnswer: "어떡해", wrongAnswer: "어떻게")]
@@ -112,7 +112,6 @@ extension TodayQuizViewController: UICollectionViewDataSource{
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-
         if todayQuizs[indexPath.item].type == QuizType.blank {
             let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: "todayQuizBlankCell", for: indexPath) as! QuizTypeBlank
             cell.data = self.todayQuizs[indexPath.item]
@@ -126,51 +125,63 @@ extension TodayQuizViewController: UICollectionViewDataSource{
             }
             
             if currentHour < openTimes[indexPath.item] {
-                print("blur \(currentHour) \(openTimes[indexPath.item])")
-                let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
-                cell.addSubview(visualEffectView)
-                visualEffectView.translatesAutoresizingMaskIntoConstraints = false
-                visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
-                visualEffectView.clipsToBounds = true
-                visualEffectView.layer.opacity = 0.9
-                NSLayoutConstraint.activate([
-                    visualEffectView.topAnchor.constraint(equalTo: cell.topAnchor),
-                    visualEffectView.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
-                    visualEffectView.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
-                    visualEffectView.bottomAnchor.constraint(equalTo: cell.bottomAnchor)
-                ])
-                
-                let imageAttachment = NSTextAttachment()
-                imageAttachment.image = UIImage(systemName: "lock.fill")
-                let fullString = NSMutableAttributedString(string: "")
-                fullString.append(NSAttributedString(attachment: imageAttachment))
-                
-                let openHour = String(format: "%02d:00", openTimes[indexPath.item])
-                fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
-                
-                let openTimeLabel = UILabel()
-                openTimeLabel.attributedText = fullString
-                cell.addSubview(openTimeLabel)
-                openTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-                NSLayoutConstraint.activate([
-                    openTimeLabel.centerXAnchor.constraint(equalTo: cell.centerXAnchor),
-                    openTimeLabel.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-                ])
+                applySecretEffect(cell: cell, hour: openTimes[indexPath.item])
             }
             return cell
         } else {
             guard let cell = todayQuizCollectionView.dequeueReusableCell(withReuseIdentifier: QuizType2CollectionViewCell.id, for: indexPath) as? QuizType2CollectionViewCell
             else { return UICollectionViewCell() }
             cell.setQuiz(quizNum: (indexPath.row) + 1, quiz: todayQuizs[indexPath.row])
+           
+            if let openTimeLabel = cell.subviews.last as? UILabel {
+                openTimeLabel.removeFromSuperview()
+                if let visualEffectView = cell.subviews.last as? UIVisualEffectView {
+                    visualEffectView.removeFromSuperview()
+                }
+            }
+
+            if currentHour < openTimes[indexPath.item] {
+                applySecretEffect(cell: cell, hour: openTimes[indexPath.item])
+            }
             return cell
         }
     }
 }
 
-extension TodayQuizViewController {
-    func applySecretEffect() {
+private extension TodayQuizViewController {
+    func getOpenTimeLabel(openHour : Int) -> UILabel {
+        let openTimeLabel = UILabel()
+        let imageAttachment = NSTextAttachment()
+        imageAttachment.image = UIImage(systemName: "lock.fill")
+        let fullString = NSMutableAttributedString(string: "")
+        fullString.append(NSAttributedString(attachment: imageAttachment))
+        let openHour = String(format: "%02d:00", openHour)
+        fullString.append(NSAttributedString(string: " \(openHour) 공개 예정"))
+        openTimeLabel.attributedText = fullString
+        return openTimeLabel
+    }
+
+    func applySecretEffect(cell: UICollectionViewCell, hour: Int) {
+        let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+        cell.addSubview(visualEffectView)
+        visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+        visualEffectView.layer.cornerRadius = TodayQuizLayoutValue.CornerRadius.cell
+        visualEffectView.clipsToBounds = true
+        visualEffectView.layer.opacity = 0.9
+        NSLayoutConstraint.activate([
+            visualEffectView.topAnchor.constraint(equalTo: cell.topAnchor),
+            visualEffectView.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+            visualEffectView.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+            visualEffectView.bottomAnchor.constraint(equalTo: cell.bottomAnchor)
+        ])
         
-        
+        let openTimeLabel = getOpenTimeLabel(openHour: hour)
+        cell.addSubview(openTimeLabel)
+        openTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            openTimeLabel.centerXAnchor.constraint(equalTo: cell.centerXAnchor),
+            openTimeLabel.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
     }
 }
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)

## Key Changes 🔥 (주요 구현/변경 사항)
- 시간에 맞게 blur를 적용하고 공개 예정 시간을 보여줍니다.
- choice 타입 cell을 todayQuiz에 연결했습니다.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/59302419/181875764-28a13515-59d4-467a-8aa9-7f30cc22a18a.png">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 질문을 코드에 코멘트로 남겨두겠습니다!

## ToDo 📆 (남은 작업)
- [ ] cell의 border를 바깥에다가 주기
- [ ] 오늘의 퀴즈 문제 받아오도록 변경
- [ ] collectionView layout 교체
- [ ] 네비게이션 연결
## ScreenShot 📷 (참고 사진)

## Reference 🔗


## Build ⚒ (Build 가능 여부)
 - [x] Yes
 - [] No

## Close Issues 🔒 (닫을 Issue)
Close #No.
