### PR TITLE
feat: 해설뷰에서 swipe로 이전 화면으로 돌아가기

### DIFF
--- a/GaNaDa/GaNaDa/View/QuizDetail/QuizDetailViewController.swift
+++ b/GaNaDa/GaNaDa/View/QuizDetail/QuizDetailViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class QuizDetailViewController: UIViewController {
     private var quiz: Quiz!
+    private var isSolved: Bool = false
     
     // Choice
     @IBOutlet weak var choiceQuizStack: UIStackView!
@@ -30,7 +31,7 @@ class QuizDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
-        setNavigationBar(navigationTitle: "퀴즈해설", hidesBackButton: true)
+        setNavigationBar(navigationTitle: "해설", popGesture: isSolved, hidesBackButton: !isSolved)
         fetchQuizDetail()
     }
     
@@ -84,8 +85,9 @@ class QuizDetailViewController: UIViewController {
     }
     
     // MARK: - Methods
-    public func prepareData(quiz: Quiz = .previewChoice) {
+    public func prepareData(quiz: Quiz = .previewChoice, isSolved: Bool = false) {
         self.quiz = quiz
+        self.isSolved = isSolved
     }
     
     @IBAction func tapToHome(_ sender: UIButton) {

--- a/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
+++ b/GaNaDa/GaNaDa/View/TodayQuiz/TodayQuizCollectionVC.swift
@@ -192,7 +192,7 @@ extension TodayQuizViewController: UICollectionViewDelegate {
                 }
             } else {
                 if let quizDetailViewController = storyboard.instantiateViewController(withIdentifier: "QuizDetailView") as? QuizDetailViewController {
-                    quizDetailViewController.prepareData(quiz : todayQuizs[indexPath.row])
+                    quizDetailViewController.prepareData(quiz : todayQuizs[indexPath.row], isSolved: true)
                     navigationController?.pushViewController(quizDetailViewController, animated: true)
                 }
             }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
해설뷰에서 swipe 및 back 버튼으로 전 화면으로 돌아갑니다.

## Key Changes 🔥 (주요 구현/변경 사항)
풀었던 문제에서 해설화면으로 가면  swipe 및 back 버튼으로 이전 화면으로 돌아갑니다.


## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
레이가 작업했습니다. 역시 레이


## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)



## Reference 🔗



## Build ⚒ (Build 가능 여부)
 - [x] Yes
 - [ ] No

## Close Issues 🔒 (닫을 Issue)
Close #No.
